### PR TITLE
lazily download ruby toolchain

### DIFF
--- a/ruby/deps.bzl
+++ b/ruby/deps.bzl
@@ -2,4 +2,5 @@ load("//ruby/private:bundle.bzl", _rb_bundle = "rb_bundle")
 load("//ruby/private:download.bzl", _rb_download = "rb_download")
 
 rb_bundle = _rb_bundle
-rb_download = _rb_download
+rb_register_toolchains = _rb_download
+rb_download = _rb_download # backwards-compatibility

--- a/ruby/private/download.bzl
+++ b/ruby/private/download.bzl
@@ -2,9 +2,9 @@ _JRUBY_BINARY_URL = "https://repo1.maven.org/maven2/org/jruby/jruby-dist/{versio
 _RUBY_BUILD_URL = "https://github.com/rbenv/ruby-build/archive/refs/tags/v{version}.tar.gz"
 _RUBY_INSTALLER_URL = "https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-{version}-1/rubyinstaller-devkit-{version}-1-x64.exe"
 
-def rb_download(**kwargs):
+def rb_download(version = None, **kwargs):
     """
-    Downloads an Ruby interpreter and registers it toolchain.
+    Register a Ruby toolchain and lazily download the Ruby Interpreter.
 
     * _(For MRI on Linux and macOS)_ Installed using [ruby-build](https://github.com/rbenv/ruby-build).
     * _(For MRI on Windows)_ Installed using [RubyInstaller](https://rubyinstaller.org).
@@ -20,11 +20,52 @@ def rb_download(**kwargs):
     )
     ```
     """
-    _rb_download(
-        name = "rules_ruby_dist",
-        **kwargs
+    repo_name = "rules_ruby_dist"
+    proxy_repo_name = "rules_ruby_toolchains"
+    if repo_name not in native.existing_rules().values():
+        _rb_download(name = repo_name, version = version, **kwargs)
+        rb_toolchain_repository_proxy(
+            name = proxy_repo_name,
+            toolchain = "@{}//:toolchain".format(repo_name),
+            toolchain_type = "@rules_ruby//ruby:toolchain_type",
+        )
+        native.register_toolchains("@{}//:all".format(proxy_repo_name))
+
+def _rb_toolchain_repository_proxy_impl(repository_ctx):
+    repository_ctx.file(
+        "WORKSPACE",
+        """workspace(name = "{}")""".format(repository_ctx.name)
     )
-    native.register_toolchains("@rules_ruby_dist//:toolchain")
+
+    build_file_template = """
+toolchain(
+    name = "{name}",
+    toolchain = "{toolchain}",
+    toolchain_type = "{toolchain_type}",
+    visibility = ["//visibility:public"],
+)
+"""
+    repository_ctx.file(
+        "BUILD",
+        build_file_template.format(
+            name = repository_ctx.attr.name,
+            toolchain = repository_ctx.attr.toolchain,
+            toolchain_type = repository_ctx.attr.toolchain_type,
+        ),
+        executable = False,
+    )
+
+rb_toolchain_repository_proxy = repository_rule(
+    implementation = _rb_toolchain_repository_proxy_impl,
+    attrs = {
+        "toolchain": attr.string(mandatory = True),
+        "toolchain_type": attr.string(mandatory = True),
+    },
+    doc = (
+        "A proxy repository that contains the toolchain declaration; this indirection " +
+        "allows the Ruby toolchain to be downloaded lazily."
+    )
+)
 
 def _rb_download_impl(repository_ctx):
     if repository_ctx.attr.version.startswith("jruby"):

--- a/ruby/private/download/BUILD.tpl
+++ b/ruby/private/download/BUILD.tpl
@@ -23,10 +23,6 @@ filegroup(
     srcs = ["dist/bin/{gem_binary_name}"],
 )
 
-toolchain_type(
-    name = "toolchain_type",
-)
-
 rb_toolchain(
     name = "toolchain",
     ruby = ":ruby",

--- a/ruby/toolchain.bzl
+++ b/ruby/toolchain.bzl
@@ -1,21 +1,3 @@
-def rb_toolchain(name, ruby, bundle, gem, bindir, version):
-    toolchain_name = "%s_toolchain" % name
-
-    _rb_toolchain(
-        name = toolchain_name,
-        ruby = ruby,
-        bundle = bundle,
-        gem = gem,
-        bindir = bindir,
-        version = version,
-    )
-
-    native.toolchain(
-        name = name,
-        toolchain = ":%s" % toolchain_name,
-        toolchain_type = "@rules_ruby//ruby:toolchain_type",
-    )
-
 def _rb_toolchain_impl(ctx):
     return platform_common.ToolchainInfo(
         ruby = ctx.executable.ruby,
@@ -25,7 +7,7 @@ def _rb_toolchain_impl(ctx):
         version = ctx.attr.version,
     )
 
-_rb_toolchain = rule(
+rb_toolchain = rule(
     implementation = _rb_toolchain_impl,
     attrs = {
         "ruby": attr.label(


### PR DESCRIPTION
Introduce a "proxy repository" to register the toolchain without actually downloading it.